### PR TITLE
Not getting price from amazon product detail page

### DIFF
--- a/amazon/spiders/amazon_search_product.py
+++ b/amazon/spiders/amazon_search_product.py
@@ -43,7 +43,7 @@ class AmazonSearchProductSpider(scrapy.Spider):
         image_data = json.loads(re.findall(r"colorImages':.*'initial':\s*(\[.+?\])},\n", response.text)[0])
         variant_data = re.findall(r'dimensionValuesDisplayData"\s*:\s* ({.+?}),\n', response.text)
         feature_bullets = [bullet.strip() for bullet in response.css("#feature-bullets li ::text").getall()]
-        price = response.css('.a-price span[aria-hidden="true"] ::text').get("")
+        price = response.css('.a-price-decimal span[aria-hidden="true"] ::text').get("")
         if not price:
             price = response.css('.a-price .a-offscreen ::text').get("")
         yield {


### PR DESCRIPTION
details
https://github.com/python-scrapy-playbook/amazon-python-scrapy-scraper/issues/4

![compare](https://github.com/user-attachments/assets/6a916bd5-12e8-4f25-bb7e-46318e78c4a9)
